### PR TITLE
Angular template: fix stylelintrc.json

### DIFF
--- a/Angular/.stylelintrc.json
+++ b/Angular/.stylelintrc.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "eslint-config-devextreme/stylelintrc",
-        "stylelint-config-standard-scss"
+        "stylelint-config-standard-scss",
+        "eslint-config-devextreme/stylelintrc"
     ]
 }


### PR DESCRIPTION
Fix the order of extended configs in angular stylelintrc.json