### PR TITLE
Examples-template: remove caret from the eslint config version.

### DIFF
--- a/Angular/package-lock.json
+++ b/Angular/package-lock.json
@@ -28,7 +28,7 @@
         "@angular/compiler-cli": "^15.1.0",
         "@types/jasmine": "~4.3.0",
         "eslint": "^8.39.0",
-        "eslint-config-devextreme": "^1.1.3",
+        "eslint-config-devextreme": "1.1.3",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "jasmine-core": "~4.5.0",
         "karma": "~6.4.0",

--- a/Angular/package.json
+++ b/Angular/package.json
@@ -34,7 +34,7 @@
     "@angular/compiler-cli": "^15.1.0",
     "@types/jasmine": "~4.3.0",
     "eslint": "^8.39.0",
-    "eslint-config-devextreme": "^1.1.3",
+    "eslint-config-devextreme": "1.1.3",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "jasmine-core": "~4.5.0",
     "karma": "~6.4.0",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- default badges list -->
-![](https://img.shields.io/endpoint?url=https://codecentral.devexpress.com/api/v1/VersionRange/340354634/22.2.3%2B)
 [![](https://img.shields.io/badge/Open_in_DevExpress_Support_Center-FF7200?style=flat-square&logo=DevExpress&logoColor=white)](https://supportcenter.devexpress.com/ticket/details/T1129779)
 [![](https://img.shields.io/badge/📖_How_to_use_DevExpress_Examples-e9f6fc?style=flat-square)](https://docs.devexpress.com/GeneralInformation/403183)
 <!-- default badges end -->

--- a/React/package-lock.json
+++ b/React/package-lock.json
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "eslint": "^8.35.0",
-        "eslint-config-devextreme": "^1.1.3",
+        "eslint-config-devextreme": "1.1.3",
         "eslint-plugin-no-only-tests": "2.6.0",
         "eslint-plugin-react": "7.31.10",
         "eslint-plugin-react-perf": "^3.3.1",

--- a/React/package.json
+++ b/React/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "eslint": "^8.35.0",
-    "eslint-config-devextreme": "^1.1.3",
+    "eslint-config-devextreme": "1.1.3",
     "eslint-plugin-no-only-tests": "2.6.0",
     "eslint-plugin-react": "7.31.10",
     "eslint-plugin-react-perf": "^3.3.1",

--- a/Vue/package-lock.json
+++ b/Vue/package-lock.json
@@ -24,7 +24,7 @@
         "@vue/test-utils": "^2.2.6",
         "@vue/tsconfig": "^0.1.3",
         "eslint": "^8.22.0",
-        "eslint-config-devextreme": "^1.1.3",
+        "eslint-config-devextreme": "1.1.3",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-vue": "^9.3.0",
         "jsdom": "^20.0.3",

--- a/Vue/package.json
+++ b/Vue/package.json
@@ -28,7 +28,7 @@
     "@vue/test-utils": "^2.2.6",
     "@vue/tsconfig": "^0.1.3",
     "eslint": "^8.22.0",
-    "eslint-config-devextreme": "^1.1.3",
+    "eslint-config-devextreme": "1.1.3",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-vue": "^9.3.0",
     "jsdom": "^20.0.3",

--- a/jQuery/package-lock.json
+++ b/jQuery/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/core": "^7.22.1",
         "@babel/eslint-parser": "^7.21.8",
         "eslint": "^8.41.0",
-        "eslint-config-devextreme": "^1.1.3",
+        "eslint-config-devextreme": "1.1.3",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "htmlhint": "^1.1.4",
         "lite-server": "^2.5.4",

--- a/jQuery/package.json
+++ b/jQuery/package.json
@@ -13,7 +13,7 @@
     "@babel/core": "^7.22.1",
     "@babel/eslint-parser": "^7.21.8",
     "eslint": "^8.41.0",
-    "eslint-config-devextreme": "^1.1.3",
+    "eslint-config-devextreme": "1.1.3",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "htmlhint": "^1.1.4",
     "lite-server": "^2.5.4",


### PR DESCRIPTION
Remove the caret from the ```eslint-config-devextreme``` package version:
```^1.1.3``` -> ```1.1.3```